### PR TITLE
control: revert changes to conflicting versions

### DIFF
--- a/bionic/debian/changelog
+++ b/bionic/debian/changelog
@@ -1,3 +1,9 @@
+sdformat10 (10.0.0~pre2-2~bionic) bionic; urgency=medium
+
+  * sdformat10 10.0.0~pre2-2 release
+
+ -- Steve Peters <scpeters@openrobotics.org>  Mon, 31 Aug 2020 16:51:01 -0700
+
 sdformat10 (10.0.0~pre2-1~bionic) bionic; urgency=medium
 
   * sdformat10 10.0.0~pre2-1 release

--- a/focal/debian/changelog
+++ b/focal/debian/changelog
@@ -1,3 +1,9 @@
+sdformat10 (10.0.0~pre2-2~focal) focal; urgency=medium
+
+  * sdformat10 10.0.0~pre2-2 release
+
+ -- Steve Peters <scpeters@openrobotics.org>  Mon, 31 Aug 2020 16:51:01 -0700
+
 sdformat10 (10.0.0~pre2-1~focal) focal; urgency=medium
 
   * sdformat10 10.0.0~pre2-1 release

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -26,12 +26,14 @@ Depends:  sdformat10-sdf (>= ${source:Version}),
           ${shlibs:Depends},
           ${misc:Depends}
 Multi-Arch: same
-Breaks: libsdformat7,
-        libsdformat8,
-        libsdformat9,
-Replaces: libsdformat7,
-          libsdformat8,
-          libsdformat9,
+Breaks: libsdformat2,
+        libsdformat3,
+        libsdformat4,
+        libsdformat5
+Replaces: libsdformat2,
+          libsdformat3,
+          libsdformat4,
+          libsdformat5
 Description: Simulation Description Format (SDF) parser - Shared library
  SDF is an XML file format that describes environments, objects, and robots
  in a manner suitable for robotic applications. SDF is capable of representing
@@ -49,12 +51,14 @@ Depends: libtinyxml2-dev,
          libignition-math6-dev,
          libsdformat10 (= ${binary:Version}),
          ${misc:Depends}
-Breaks: libsdformat7-dev,
-        libsdformat8-dev,
-        libsdformat9-dev,
-Replaces: libsdformat7-dev,
-          libsdformat8-dev,
-          libsdformat9-dev,
+Breaks: libsdformat2-dev,
+        libsdformat3-dev,
+        libsdformat4-dev,
+        libsdformat5-dev
+Replaces: libsdformat2-dev,
+        libsdformat3-dev,
+        libsdformat4-dev,
+        libsdformat5-dev
 Multi-Arch: same
 Description: Simulation Description Format (SDF) parser - Development files
  SDF is an XML file format that describes environments, objects, and robots


### PR DESCRIPTION
`libsdformat` versions used to conflict with each other, but newer versions of these packages should not conflict with each other. A script was used to create this repo from sdformat9-release in bdf65c00377ce155d1d8111ed662da8c1904e48c, and changed the  "Breaks" and "Replaces" metadata to refer to newer packages. I believe this shouldn't be necessary, so I've reverted that aspect here.

* https://github.com/ignition-release/sdformat10-release/commit/bdf65c00377ce155d1d8111ed662da8c1904e48c#diff-8f4713d4e11b5056ae65b1f345e15a25

Without this, `libsdformat9` and `libsdformat10` cannot be installed side-by-side.