### PR TITLE
Add build-depend on pkg-config to find urdfdom

### DIFF
--- a/focal/debian/control
+++ b/focal/debian/control
@@ -5,6 +5,7 @@ Section: science
 Priority: optional
 Build-Depends: cmake,
                debhelper (>= 9),
+               pkg-config,
                python3,
                libtinyxml2-dev,
                doxygen,

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -5,6 +5,7 @@ Section: science
 Priority: optional
 Build-Depends: cmake,
                debhelper (>= 9),
+               pkg-config,
                python,
                libtinyxml2-dev,
                doxygen,

--- a/ubuntu/debian/libsdformat-dev.install
+++ b/ubuntu/debian/libsdformat-dev.install
@@ -1,6 +1,6 @@
 usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
-usr/lib/*/cmake/sdformat10/*
+usr/lib/*/cmake/sdformat10*/*
 usr/lib/ruby/ignition/*.rb
 usr/share/ignition/*.yaml


### PR DESCRIPTION
I noticed that the 10.7.0~pre1 debbuilds failed to compile some tests with complaints about finding urdf headers:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat10-debbuilder&build=242)](https://build.osrfoundation.org/job/sdformat10-debbuilder/242/) https://build.osrfoundation.org/job/sdformat10-debbuilder/242

~~~
src/parser_urdf.cc:30:10: fatal error: urdf_model/model.h: No such file or directory
 #include <urdf_model/model.h>
          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
src/CMakeFiles/UNIT_ParamPassing_TEST.dir/build.make:257: recipe for target
 'src/CMakeFiles/UNIT_ParamPassing_TEST.dir/parser_urdf.cc.o' failed
~~~

It turns out there was a bug in 10.7.0~pre1 when `USE_INTERNAL_URDF == TRUE`, and the debbuilds were unintentionally failing to find the external urdfdom since `pkg-config` was not found. I've added `pkg-config` as a `build-depend` in the control file here, which should fix the 10.7.0~pre1 builds.

Separately, I've submitted a fix for the compilation error when `USE_INTERNAL_URDF == TRUE` in https://github.com/ignitionrobotics/sdformat/pull/800