### PR TITLE
Fix install rules for sdformat10-all cmake files

### DIFF
--- a/ubuntu/debian/libsdformat-dev.install
+++ b/ubuntu/debian/libsdformat-dev.install
@@ -1,6 +1,6 @@
 usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
-usr/lib/*/cmake/sdformat10/*
+usr/lib/*/cmake/sdformat10*/*
 usr/lib/ruby/ignition/*.rb
 usr/share/ignition/*.yaml


### PR DESCRIPTION
Split out from https://github.com/ignition-release/sdformat10-release/pull/7, motivated by the following unstable debbuild:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat10-debbuilder&build=245)](https://build.osrfoundation.org/job/sdformat10-debbuilder/245/) https://build.osrfoundation.org/job/sdformat10-debbuilder/245/